### PR TITLE
add index to bitwise hash to reduce conflicts!

### DIFF
--- a/ImageManager.swift
+++ b/ImageManager.swift
@@ -159,8 +159,8 @@ public class ImageManager {
             url = url[url.startIndex..<advance(url.startIndex,len)]
         }
         var hash: UInt32 = 0
-        for codeUnit in url.utf8 {
-            hash += UInt32(codeUnit)
+        for (index, codeUnit) in enumerate(url.utf8) {
+            hash += (UInt32(codeUnit) * UInt32(index))
             hash ^= (hash >> 6)
         }
         


### PR DESCRIPTION
I think with adding index to bitwise hash we could remove some conflicts. For example, if we do not use index multiplier `xyz` and `yxz` will have same hash but with multiplier they have different hash!
